### PR TITLE
Version 1.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,24 @@
-# GridFields
+## Gridfields
 
-For reference, see
+Scientists' ability to generate and store simulation results is outpacing their ability to analyze them via ad hoc programs. We observe that these programs exhibit an algebraic structure that can be used to facilitate reasoning and improve performance.
 
- * Bill Howe, David Maier, "Algebraic Manipulation of Scientific Datasets", VLDB Journal 2005
+In our work on GridFields, we present a formal data model that exposes this algebraic structure, then implement the model, evaluate it, and use it to express, optimize, and reason about data transformations in a variety of scientific domains.
 
- * Bill Howe, Model-Driven Data Transformation in the Physical Sciences, Doctoral Dissertation, Portland State University, 2006
+Simulation results are defined over a logical grid structure that allows a continuous domain to be represented discretely in the computer. Existing approaches for manipulating these gridded datasets are incomplete. The performance of SQL queries that manipulate large numeric datasets is not competitive with that of specialized tools, and the up-front effort required to deploy a relational database makes them unpopular for dynamic scientific applications. Tools for processing multidimensional arrays can only capture regular, rectilinear grids. Visualization libraries accommodate some forms of unstructured grid, but no algebra has been developed to organize the library of raw algorithms and afford optimization. Further, these libraries are data dependent---physical changes to data characteristics break user programs.
 
-# Directory structure
-/src contains c++ source 
+The GridFields library exposes 1) topological equivalences among gridded datasets and 2) logical equivalences among grid-oriented programs. These equivalences offer optimization opportunities and simplify programming.
 
-/gridfield contains python bindings implemented using SWIG and python support modules 
+We adopt the grid as a first-class citizen, separating topology from geometry and separating structure from data. Our model is agnostic with respect to dimension, uniformly capturing, for example, particle trajectories (1-D), sea-surface temperatures (2-D), and blood flow in the heart (3-D). Equipped with data, a grid becomes a gridfield. We provide operators for constructing, transforming, and aggregating gridfields that admit algebraic laws useful for optimization. We implement the model by analyzing several candidate data structures and incorporating their best features. We then show how to deploy gridfields in practice by injecting the model as middleware between heterogeneous, ad hoc file formats and a popular visualization library.
 
-/gridfield_server is an XML-RPC server for evaluating remote gridfield expressions /vistrails_package is a package for the VisTrails workflow system
+In this project, we define, develop, implement, evaluate and deploy a model of gridded datasets that accommodates a variety of complex grid structures and a variety of complex data products. We evaluate the applicability and performance of the model using datasets from oceanography, seismology, and medicine and conclude that our model-driven approach offers significant advantages over the status quo.
 
-# Requirements
-Python 2.4+ swig 1.3+ netcdf 3+ (with headers) VTK 4.2+ (optional, if vtk not detected through python, visualization components will not be built )
+Here at CMOP, we use GridFields to implement query services over ocean circulation model results, and we have added a GridFields plugin module for the VisTrails provenance and visualization system.
 
-## Installation of the gridfield python package
-Note: VTK headers are frequently installed in strange places. If you plan to use VTK, edit the setup.py file and change the value of vtkincl $ python setup.py build $ python setup.py install
+## Installation
+There are two packages: a C library (clib) and SWIG python bindings (pygridfields)
+See README files in these directories for more information
 
-##Installation of VisTrails Package
+## References
+ * GridFields: Model-Driven Data Transformation in the Physical Sciences, Bill Howe, Phd Dissertation, Portland State University, 2007.
+ * Algebraic Manipulation of Scientific Datasets Bill Howe, David Maier VLDB Journal, 14(4), November 2005
 
-cp -LR vistrails_package/gridfield ~/.vistrails/userpackages cp vistrails_package/examples/gridfieldexample.xml $VISTRAILS/examples
-
-Enable the package in VisTrails: Menu Edit > Preferences (Mac: Menu VisTrails > Preferences)
-
-# Examples
-A version tree showing how to use gridfields to access CORIE data is at vistrails_package/gridfieldexample.xml
-
-# Build Instructions: Makefile
-If you want to compile the library yourself (perhaps to compile bindings for a different language), you can modify the SWIG Makefile(s) in gridfield/ and the c++ Makefile in src/.
-
-`cd gridfield`
-
-edit Makefile so that libraries and include files # for Python and VTK are correct. # Also verify the compiler and associated settings. then:
-
-`make gridfield make gfvis`
-
-to test that gridfields can be imported in python, run python test.py # and verify that it generates simple output

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# GridFields
+
+For reference, see
+
+ * Bill Howe, David Maier, "Algebraic Manipulation of Scientific Datasets", VLDB Journal 2005
+
+ * Bill Howe, Model-Driven Data Transformation in the Physical Sciences, Doctoral Dissertation, Portland State University, 2006
+
+# Directory structure
+/src contains c++ source 
+
+/gridfield contains python bindings implemented using SWIG and python support modules 
+
+/gridfield_server is an XML-RPC server for evaluating remote gridfield expressions /vistrails_package is a package for the VisTrails workflow system
+
+# Requirements
+Python 2.4+ swig 1.3+ netcdf 3+ (with headers) VTK 4.2+ (optional, if vtk not detected through python, visualization components will not be built )
+
+## Installation of the gridfield python package
+Note: VTK headers are frequently installed in strange places. If you plan to use VTK, edit the setup.py file and change the value of vtkincl $ python setup.py build $ python setup.py install
+
+##Installation of VisTrails Package
+
+cp -LR vistrails_package/gridfield ~/.vistrails/userpackages cp vistrails_package/examples/gridfieldexample.xml $VISTRAILS/examples
+
+Enable the package in VisTrails: Menu Edit > Preferences (Mac: Menu VisTrails > Preferences)
+
+# Examples
+A version tree showing how to use gridfields to access CORIE data is at vistrails_package/gridfieldexample.xml
+
+# Build Instructions: Makefile
+If you want to compile the library yourself (perhaps to compile bindings for a different language), you can modify the SWIG Makefile(s) in gridfield/ and the c++ Makefile in src/.
+
+`cd gridfield`
+
+edit Makefile so that libraries and include files # for Python and VTK are correct. # Also verify the compiler and associated settings. then:
+
+`make gridfield make gfvis`
+
+to test that gridfields can be imported in python, run python test.py # and verify that it generates simple output

--- a/clib/ChangeLog
+++ b/clib/ChangeLog
@@ -1,3 +1,8 @@
+2015-12-04  Nathan Potter  <ndp@opendap.org>
+
+	Changed so gridfields-config returns correct include dir, again.
+
+	Changed so gridfields-config returns correct include dir.
 2015-12-02  Nathan Potter  <ndp@opendap.org>
 
 	Updated version number for release.

--- a/clib/ChangeLog
+++ b/clib/ChangeLog
@@ -1,3 +1,132 @@
+2015-12-02  Nathan Potter  <ndp@opendap.org>
+
+	Updated version number for release.
+
+2015-12-02  billhowe  <billhowe@cs.washington.edu>
+
+	Update README.md
+
+	Create README.md
+
+2015-12-02  James Gallagher  <jgallagher@opendap.org>
+
+	Added a comment about --disable-netcdf
+
+	fill-region on the README so work with more
+
+	Fixed an error in testerror.cc - missing EXIT_SUCCESS definition.
+	... also hacked configure.ac so it uses the AS_IF macro. Just pedantry...
+
+2015-11-25  Nathan Potter  <ndp@opendap.org>
+
+	Improved error message from Dataset:Apply()
+
+	Added NDEBUG check for warning output.
+
+	Added NDEBUG check for warning output.
+
+	First crack at improved error handling
+
+	First crack at improved error handling
+
+	First crack at improved error handling
+
+	Added .gitignore
+
+2014-04-22  jgallagher  <jgallagher@opendap.org>
+
+	Added a spec file and -config script
+	A    gridfields-config.in
+	M    configure.ac
+	M    gridfields.spec
+	M    Makefile.am
+
+2014-04-21  jgallagher  <jgallagher@opendap.org>
+
+	Added stuff to make a RPM
+	A    gridfields.spec
+	A    COPYING
+	M    Makefile.am
+
+	Added the four 'generated source' tests
+	M    configure.ac
+
+	Modified four of the tests so they use generated source since paths to data files are baked into them and those were breaking the distcheck target
+	D    tests/testoutput.cc
+	A    tests/testoutput.cc.in
+	A    tests/testarrayreader.cc.in
+	A    tests/testcross.cc.in
+	D    tests/testarrayreader.cc
+	D    tests/testbind.cc
+	A    tests/testbind.cc.in
+	M    tests/Makefile.am
+	D    tests/testcross.cc
+
+2014-04-11  jgallagher  <jgallagher@opendap.org>
+
+	formatted the code so it's a bit more consistent
+
+2014-04-10  jgallagher  <jgallagher@opendap.org>
+
+	audit
+
+	Reformatted elio.c/.h
+
+2014-04-08  jgallagher  <jgallagher@opendap.org>
+
+	Compiler warnings about deprecated code added - it's bummer but the tr1/unordered_map is not used on Centos 6.
+	M    tests/Makefile.am
+	M    Makefile.am
+
+	Changes for OSX 10.5 - g++ 4.0.0 Removed bugus files in conf - they are generated
+	M    configure.ac
+	D    conf/ltsugar.m4
+	D    conf/libtool.m4
+	D    conf/ltversion.m4
+	D    conf/depcomp
+	D    conf/lt~obsolete.m4
+	D    conf/missing
+	D    conf/ltoptions.m4
+	D    conf/config.guess
+	D    conf/ltmain.sh
+	D    conf/config.sub
+	D    conf/install-sh
+	M    src/access.h
+	M    src/unarynodemap.h
+	M    src/binarynodemap.h
+
+	Build fixes for g++ 4.4.7 on CentOS 6.
+	M    configure.ac
+	M    conf/libtool.m4
+	M    conf/ltversion.m4
+	M    conf/depcomp
+	M    conf/missing
+	M    conf/ltoptions.m4
+	M    conf/config.guess
+	M    conf/ltmain.sh
+	M    conf/config.sub
+	M    conf/install-sh
+	M    src/rankeddataset.h
+	M    src/expr.cc
+	M    src/tuple.cc
+	M    src/cellarray.cc
+	M    src/grid.cc
+
+2014-04-07  jgallagher  <jgallagher@opendap.org>
+
+	More hackery for a decent build...
+	M    ChangeLog
+	M    Makefile.am
+	M    NEWS
+	M    configure.ac
+	_M   src
+	M    src/cell.h
+	M    src/cellarray.h
+	M    src/expr.h
+	M    src/grid.h
+	A    src/gridfields_hash_map.h.in
+	M    src/normnodemap.h
+	M    tests/Makefile.am
 2014-04-04  jgallagher@opendap.org
 
 	Removed warnings except for cast-align, deprecated and

--- a/clib/NEWS
+++ b/clib/NEWS
@@ -1,3 +1,9 @@
+Version 1.0.4
+
+Improved error handling by adding an error object class (GFError) that is 
+thrown. Thus allows client software to catch GridFields errors and return 
+senisble messages to their users.
+
 Version 1.0.3
 
 Fixed the warnings (many many) that were issued when code used this

--- a/clib/NEWS
+++ b/clib/NEWS
@@ -1,3 +1,8 @@
+Version 1.0.5
+
+Repair bug in gridfields-config script that was returning the incorrect
+include direcoty for the cflags option.
+
 Version 1.0.4
 
 Improved error handling by adding an error object class (GFError) that is 

--- a/clib/configure.ac
+++ b/clib/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.63])
-AC_INIT([gridfields], [1.0.3], [Bill Howe <billhowe@cs.washington.edu>])
+AC_INIT([gridfields], [1.0.4], [Bill Howe <billhowe@cs.washington.edu>])
 AC_CONFIG_SRCDIR([src/abstractcellarray.h])
 # This has to be named specially since it's included in headers that
 # are installed. The config header defines compile-time switches that 

--- a/clib/configure.ac
+++ b/clib/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.63])
-AC_INIT([gridfields], [1.0.4], [Bill Howe <billhowe@cs.washington.edu>])
+AC_INIT([gridfields], [1.0.5], [Bill Howe <billhowe@cs.washington.edu>])
 AC_CONFIG_SRCDIR([src/abstractcellarray.h])
 # This has to be named specially since it's included in headers that
 # are installed. The config header defines compile-time switches that 

--- a/clib/gridfields-config.in
+++ b/clib/gridfields-config.in
@@ -56,7 +56,7 @@ while test $# -gt 0; do
 	;;
 
     --cflags)
-	echo "-I${includedir}/libgridfields"
+	echo "-I${includedir}/gridfields"
 	;;
 
     --libs)

--- a/clib/gridfields-config.in
+++ b/clib/gridfields-config.in
@@ -56,7 +56,7 @@ while test $# -gt 0; do
 	;;
 
     --cflags)
-	echo "-I${includedir}/gridfields"
+	echo "-I${includedir}"
 	;;
 
     --libs)


### PR DESCRIPTION
I would like to make a new release of the library that encompasses the error handling changes along with some configuration updates. The version jumps by 2 revs because I did these two things during a period when I did not have permissions to contribute to the project. I don't propose to keep this branch around after I merge it to the master branch, but rather I will tag the master with version-1.0.5 once it's all merged and checked in.

Version 1.0.5

Repair bug in gridfields-config script that was returning the incorrect
include direcoty for the cflags option.

Version 1.0.4

Improved error handling by adding an error object class (GFError) that is 
thrown. Thus allows client software to catch GridFields errors and return 
senisble messages to their users.
